### PR TITLE
Fix a crash when the segment does not point to a source file

### DIFF
--- a/code.js
+++ b/code.js
@@ -476,7 +476,7 @@
     }
 
     // Update the original text area when the source changes
-    const otherSource = index => sm.sources[index].name;
+    const otherSource = index => index === -1 ? 'unmapped' : sm.sources[index].name;
     const originalName = index => sm.names[index];
     originalTextArea = null;
     if (sm.sources.length > 0) {


### PR DESCRIPTION
With the following example:
```js
var foo = function () {
  return 4;
};

//# sourceMappingURL=data:application/json;charset=utf-8;base64,ewogICJtYXBwaW5ncyI6ICJBQUFBLElBQUEsR0FBQSxHQUFVLFk7U0FBTSxDO0FBQUMsQ0FBakIiLAogICJuYW1lcyI6IFtdLAogICJzb3VyY2VzIjogWyJvcmlnaW5hbC5qcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsidmFyIGZvbyA9ICgpID0+IDQ7Il0sCiAgInZlcnNpb24iOiAzCn0K
```

Hovering over the `{` or `;` (on line 2) in the Generated Code section causes a crash. The actual mappings looks like:

```
AAAA,IAAA,GAAA,GAAU,Y;SAAM,C;AAAC,CAAjB
```

Where the `Y` and `C` segments do not have a `sourcesIndex`/`sourceLine`/`sourceColumn` VLQ. This defaults the source `index` variable here to `-1`, which causes the crash.