### PR TITLE
Add license file on behalf of author

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright © 2023 Evan Wallace  https://madebyevan.com/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I'd also like to see a license for this project, and so this is an attempt to make it really easy on @evanw to do so, if he is willing to choose the MIT license.

Addresses:
https://github.com/evanw/source-map-visualization/issues/16

I got the boilerplate from here:
https://serverside-boilerplate.mit-license.org/

@evanw I also see you happen to be the author of esbuild.  thank you so much for that!  I use it everyday and it's life changing.